### PR TITLE
OSS portfolio: feature ccl/idd, landing pages, sync logos

### DIFF
--- a/public/images/projects/agent-skill-manager.svg
+++ b/public/images/projects/agent-skill-manager.svg
@@ -1,24 +1,34 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="none">
-  <rect width="512" height="512" rx="112" fill="#0A0A0A"/>
+  <!-- App icon: dark background with rounded corners -->
+  <rect width="512" height="512" rx="80" fill="#0a0a0a"/>
 
-  <!-- Universal globe ring -->
-  <circle cx="256" cy="240" r="120" stroke="#22C55E" stroke-width="8" fill="none"/>
-  <ellipse cx="256" cy="240" rx="60" ry="120" stroke="#22C55E" stroke-width="5" fill="none"/>
-  <line x1="136" y1="240" x2="376" y2="240" stroke="#22C55E" stroke-width="5"/>
-  <line x1="152" y1="190" x2="360" y2="190" stroke="#374151" stroke-width="4"/>
-  <line x1="152" y1="290" x2="360" y2="290" stroke="#374151" stroke-width="4"/>
+  <g transform="translate(48, 48) scale(0.8125)">
+    <!-- Radiating paths -->
+    <line x1="256" y1="216" x2="256" y2="88" stroke="#00ff41" stroke-width="10" stroke-linecap="square"/>
+    <line x1="291" y1="236" x2="401" y2="136" stroke="#00ff41" stroke-width="10" stroke-linecap="square"/>
+    <line x1="291" y1="276" x2="401" y2="376" stroke="#00ff41" stroke-width="10" stroke-linecap="square"/>
+    <line x1="256" y1="296" x2="256" y2="424" stroke="#00ff41" stroke-width="10" stroke-linecap="square"/>
+    <line x1="221" y1="276" x2="111" y2="376" stroke="#00ff41" stroke-width="10" stroke-linecap="square"/>
+    <line x1="221" y1="236" x2="111" y2="136" stroke="#00ff41" stroke-width="10" stroke-linecap="square"/>
 
-  <!-- Skills nodes around -->
-  <circle cx="256" cy="120" r="14" fill="#22C55E"/>
-  <circle cx="376" cy="240" r="14" fill="#22C55E"/>
-  <circle cx="136" cy="240" r="14" fill="#22C55E"/>
-  <circle cx="256" cy="360" r="14" fill="#22C55E"/>
+    <!-- Central hex -->
+    <polygon points="256,204 296,230 296,282 256,308 216,282 216,230" fill="#0a0a0a" stroke="#00ff41" stroke-width="12"/>
+    <circle cx="256" cy="256" r="10" fill="#00ff41"/>
 
-  <!-- Center agent core -->
-  <circle cx="256" cy="240" r="28" fill="#22C55E"/>
-  <circle cx="256" cy="240" r="16" fill="#0A0A0A"/>
+    <!-- Outer nodes -->
+    <polygon points="256,52 280,76 256,100 232,76" fill="#00ff41"/>
+    <rect x="394" y="108" width="44" height="44" fill="#00ff41" rx="3"/>
+    <circle cx="420" cy="392" r="24" fill="#00ff41"/>
+    <rect x="234" y="416" width="44" height="44" fill="#00ff41" rx="10"/>
+    <polygon points="96,376 120,352 144,376 120,400" fill="#00ff41"/>
+    <circle cx="96" cy="130" r="24" fill="#00ff41" opacity="0.7"/>
 
-  <!-- Label bar -->
-  <rect x="160" y="400" width="192" height="36" rx="8" fill="#111111" stroke="#22C55E" stroke-width="2"/>
-  <text x="256" y="424" text-anchor="middle" fill="#22C55E" font-family="monospace" font-size="16" font-weight="bold">ASM</text>
+    <!-- Skill particles -->
+    <circle cx="256" cy="156" r="5" fill="#00ff41" opacity="0.4"/>
+    <circle cx="340" cy="190" r="5" fill="#00ff41" opacity="0.4"/>
+    <circle cx="340" cy="322" r="5" fill="#00ff41" opacity="0.4"/>
+    <circle cx="256" cy="360" r="5" fill="#00ff41" opacity="0.4"/>
+    <circle cx="172" cy="322" r="5" fill="#00ff41" opacity="0.4"/>
+    <circle cx="172" cy="190" r="5" fill="#00ff41" opacity="0.4"/>
+  </g>
 </svg>

--- a/public/images/projects/cc-context-stats.svg
+++ b/public/images/projects/cc-context-stats.svg
@@ -1,26 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
-  <!-- App icon — square with padding and rounded corners -->
-  <rect width="512" height="512" rx="96" fill="#000000"/>
+  <defs>
+    <linearGradient id="ctxFill" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#10B981"/>
+      <stop offset="1" stop-color="#06B6D4"/>
+    </linearGradient>
+  </defs>
 
-  <!-- Gauge track (background) -->
-  <path d="M 96 352 A 176 176 0 1 1 416 352" stroke="#111111" stroke-width="38" fill="none" stroke-linecap="round"/>
+  <!-- Background: rounded square, deep navy -->
+  <rect width="512" height="512" rx="96" fill="#0F172A"/>
 
-  <!-- Green zone (0-40%) -->
-  <path d="M 96 352 A 176 176 0 0 1 145.6 194.8" stroke="#22C55E" stroke-width="38" fill="none" stroke-linecap="round"/>
-
-  <!-- Yellow zone (40-80%) -->
-  <path d="M 145.6 194.8 A 176 176 0 0 1 366.4 194.8" stroke="#F59E0B" stroke-width="38" fill="none" stroke-linecap="round"/>
-
-  <!-- Red zone (80-100%) -->
-  <path d="M 366.4 194.8 A 176 176 0 0 1 416 352" stroke="#EF4444" stroke-width="38" fill="none" stroke-linecap="round"/>
-
-  <!-- Needle at ~55% -->
-  <line x1="256" y1="256" x2="168" y2="168" stroke="#FFFFFF" stroke-width="20" stroke-linecap="round"/>
-
-  <!-- Pivot dot -->
-  <circle cx="256" cy="256" r="24" fill="#22C55E"/>
-
-  <!-- Label dots at zone boundaries -->
-  <circle cx="96" cy="352" r="8" fill="#6B7280"/>
-  <circle cx="416" cy="352" r="8" fill="#6B7280"/>
+  <!-- Mark: canonical 64x64 geometry scaled 6x, centered.
+       translate(64, 64) scale(6) maps the 64-box to 384px centered in 512 -->
+  <g transform="translate(64, 64) scale(6)">
+    <rect x="13" y="22" width="38" height="20" rx="6" fill="none" stroke="#334155" stroke-width="2.5"/>
+    <rect x="17" y="26" width="18" height="12" rx="3" fill="url(#ctxFill)"/>
+    <rect x="36" y="24.5" width="2.5" height="15" rx="1.25" fill="#06B6D4"/>
+    <rect x="44" y="28" width="3" height="8" rx="1.5" fill="#818CF8" opacity="0.8"/>
+    <circle cx="48" cy="17" r="2.5" fill="#818CF8" opacity="0.7"/>
+  </g>
 </svg>

--- a/public/images/projects/ccl.svg
+++ b/public/images/projects/ccl.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="none">
+  <!-- Outer rounded square background for app icon -->
+  <rect width="512" height="512" rx="112" fill="#0A0A0A"/>
+  <!-- Inner mark scaled up: base 64x64 → 360x360, centered in 512
+       scale = 360/64 = 5.625
+       translate: (512-360)/2 = 76 on each axis
+       But internal mark rect starts at 0,0 so just scale and translate to center -->
+  <g transform="translate(76,76) scale(5.625)">
+    <rect width="64" height="64" rx="14" fill="#111111"/>
+    <!-- Starburst rays (stroke-width divided by scale: 2.2/5.625 ≈ 0.39, 2.8/5.625 ≈ 0.498) -->
+    <line x1="32" y1="6"  x2="32" y2="18" stroke="#A1A1A1" stroke-width="0.39" stroke-linecap="round"/>
+    <line x1="32" y1="46" x2="32" y2="58" stroke="#A1A1A1" stroke-width="0.39" stroke-linecap="round"/>
+    <line x1="6"  y1="32" x2="18" y2="32" stroke="#A1A1A1" stroke-width="0.39" stroke-linecap="round"/>
+    <line x1="46" y1="32" x2="58" y2="32" stroke="#A1A1A1" stroke-width="0.39" stroke-linecap="round"/>
+    <line x1="13.5" y1="13.5" x2="21.9" y2="21.9" stroke="#A1A1A1" stroke-width="0.39" stroke-linecap="round"/>
+    <line x1="42.1" y1="42.1" x2="50.5" y2="50.5" stroke="#A1A1A1" stroke-width="0.39" stroke-linecap="round"/>
+    <line x1="50.5" y1="13.5" x2="42.1" y2="21.9" stroke="#A1A1A1" stroke-width="0.39" stroke-linecap="round"/>
+    <line x1="13.5" y1="50.5" x2="21.9" y2="42.1" stroke="#A1A1A1" stroke-width="0.39" stroke-linecap="round"/>
+    <!-- >_ prompt -->
+    <path d="M22,27 L28,32 L22,37" stroke="#00FF41" stroke-width="0.498" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <line x1="31" y1="37" x2="39" y2="37" stroke="#00FF41" stroke-width="0.498" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/public/images/projects/doc-bases.svg
+++ b/public/images/projects/doc-bases.svg
@@ -1,42 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 120" width="400" height="120">
-  <defs>
-    <style>
-      @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&amp;display=swap');
-    </style>
-  </defs>
-  <!-- Background -->
-  <rect width="400" height="120" fill="#FFFFFF" rx="8"/>
-
-  <!-- Document + Search Symbol -->
-  <g transform="translate(26, 14)">
-    <!-- Document body -->
-    <rect x="8" y="0" width="48" height="64" rx="4" fill="none" stroke="#000000" stroke-width="2.5"/>
-    <!-- Folded corner -->
-    <path d="M42 0 L56 14 L42 14 Z" fill="#E5E7EB" stroke="#000000" stroke-width="2" stroke-linejoin="round"/>
-    <!-- Text lines on document -->
-    <line x1="16" y1="24" x2="40" y2="24" stroke="#6B7280" stroke-width="2" stroke-linecap="round"/>
-    <line x1="16" y1="32" x2="36" y2="32" stroke="#6B7280" stroke-width="2" stroke-linecap="round"/>
-    <line x1="16" y1="40" x2="42" y2="40" stroke="#6B7280" stroke-width="2" stroke-linecap="round"/>
-    <line x1="16" y1="48" x2="30" y2="48" stroke="#6B7280" stroke-width="2" stroke-linecap="round"/>
-
-    <!-- Magnifying glass (overlapping bottom-right) -->
-    <circle cx="54" cy="60" r="14" fill="#FFFFFF" stroke="#22C55E" stroke-width="2.5"/>
-    <line x1="64" y1="70" x2="74" y2="80" stroke="#22C55E" stroke-width="3" stroke-linecap="round"/>
-    <!-- Search highlight inside glass -->
-    <circle cx="54" cy="60" r="6" fill="none" stroke="#22C55E" stroke-width="1" opacity="0.4"/>
-    <!-- Small dot in center of glass -->
-    <circle cx="54" cy="60" r="2" fill="#22C55E" opacity="0.6"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <rect width="512" height="512" rx="96" fill="#FFFFFF"/>
+  <g transform="translate(96, 96) scale(2.667)">
+    <g transform="translate(18, 18)">
+      <rect x="12" y="4" width="48" height="64" rx="4" fill="none" stroke="#000000" stroke-width="2.5"/>
+      <path d="M46 4 L60 18 L46 18 Z" fill="#E5E7EB" stroke="#000000" stroke-width="2" stroke-linejoin="round"/>
+      <line x1="20" y1="28" x2="44" y2="28" stroke="#6B7280" stroke-width="2" stroke-linecap="round"/>
+      <line x1="20" y1="36" x2="40" y2="36" stroke="#6B7280" stroke-width="2" stroke-linecap="round"/>
+      <line x1="20" y1="44" x2="46" y2="44" stroke="#6B7280" stroke-width="2" stroke-linecap="round"/>
+      <line x1="20" y1="52" x2="34" y2="52" stroke="#6B7280" stroke-width="2" stroke-linecap="round"/>
+      <circle cx="58" cy="64" r="14" fill="#FFFFFF" stroke="#22C55E" stroke-width="2.5"/>
+      <line x1="68" y1="74" x2="78" y2="84" stroke="#22C55E" stroke-width="3" stroke-linecap="round"/>
+      <circle cx="58" cy="64" r="6" fill="none" stroke="#22C55E" stroke-width="1" opacity="0.4"/>
+      <circle cx="58" cy="64" r="2" fill="#22C55E" opacity="0.6"/>
+    </g>
   </g>
-
-  <!-- Wordmark -->
-  <text x="122" y="58" font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-weight="700" font-size="34" fill="#000000">doc</text>
-  <text x="187" y="58" font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-weight="700" font-size="34" fill="#6B7280">-</text>
-  <text x="200" y="58" font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-weight="700" font-size="34" fill="#22C55E">bases</text>
-
-  <!-- Tagline -->
-  <text x="122" y="80" font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-weight="400" font-size="11" fill="#6B7280">Intelligent answers from any document.</text>
-<<<<<<< Updated upstream
 </svg>
-=======
-</svg>
->>>>>>> Stashed changes

--- a/public/images/projects/doc-bases.svg
+++ b/public/images/projects/doc-bases.svg
@@ -35,4 +35,8 @@
 
   <!-- Tagline -->
   <text x="122" y="80" font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-weight="400" font-size="11" fill="#6B7280">Intelligent answers from any document.</text>
+<<<<<<< Updated upstream
 </svg>
+=======
+</svg>
+>>>>>>> Stashed changes

--- a/public/images/projects/idd.svg
+++ b/public/images/projects/idd.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <!-- App icon: mark centered on dark rounded square -->
+  <rect width="512" height="512" rx="96" fill="#0A0A0A"/>
+
+  <g transform="translate(96, 96) scale(2.667)">
+    <path fill-rule="evenodd" fill="#00FF41"
+          d="M60 12 L108 60 L60 108 L12 60 Z
+             M48 46 L80 60 L48 74 Z"/>
+  </g>
+</svg>

--- a/public/images/projects/repo-insights.svg
+++ b/public/images/projects/repo-insights.svg
@@ -1,26 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="none">
-  <rect width="512" height="512" rx="112" fill="#0A0A0A"/>
-
-  <!-- Chart area -->
-  <rect x="80" y="100" width="352" height="280" rx="16" fill="#111111" stroke="#1A1A1A" stroke-width="4"/>
-
-  <!-- Grid lines -->
-  <line x1="120" y1="160" x2="392" y2="160" stroke="#1A1A1A" stroke-width="2"/>
-  <line x1="120" y1="220" x2="392" y2="220" stroke="#1A1A1A" stroke-width="2"/>
-  <line x1="120" y1="280" x2="392" y2="280" stroke="#1A1A1A" stroke-width="2"/>
-  <line x1="120" y1="340" x2="392" y2="340" stroke="#1A1A1A" stroke-width="2"/>
-
-  <!-- Bar chart -->
-  <rect x="140" y="240" width="36" height="100" rx="4" fill="#22C55E"/>
-  <rect x="196" y="180" width="36" height="160" rx="4" fill="#22C55E" opacity="0.8"/>
-  <rect x="252" y="200" width="36" height="140" rx="4" fill="#22C55E" opacity="0.6"/>
-  <rect x="308" y="160" width="36" height="180" rx="4" fill="#F59E0B"/>
-  <rect x="364" y="260" width="36" height="80" rx="4" fill="#22C55E" opacity="0.4"/>
-
-  <!-- Trend line -->
-  <polyline points="158,230 214,170 270,190 326,150 382,250" stroke="#FFFFFF" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-
-  <!-- Eye icon (insights) -->
-  <ellipse cx="256" cy="430" rx="48" ry="24" fill="none" stroke="#22C55E" stroke-width="5"/>
-  <circle cx="256" cy="430" r="12" fill="#22C55E"/>
+  <!-- Background with rounded corners for app icon -->
+  <rect width="512" height="512" rx="96" fill="#0A0A0A"/>
+  <!-- Eye/lens mark centered with padding -->
+  <g transform="translate(48,48) scale(0.8125)">
+    <path d="M56 256 C56 256 140 96 256 96 C372 96 456 256 456 256 C456 256 372 416 256 416 C140 416 56 256 56 256Z" fill="#39FF14"/>
+    <circle cx="256" cy="256" r="96" fill="#0A0A0A"/>
+    <circle cx="256" cy="256" r="40" fill="#39FF14"/>
+    <circle cx="232" cy="232" r="14" fill="#FFFFFF" opacity="0.9"/>
+  </g>
 </svg>

--- a/public/images/projects/sleek-ui.svg
+++ b/public/images/projects/sleek-ui.svg
@@ -1,10 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
-  <!-- Top-left horizontal bar -->
-  <line x1="10" y1="14" x2="38" y2="14" stroke="#FAFAFA" stroke-width="4" stroke-linecap="square"/>
-  <!-- Diagonal stroke: top-right down to bottom-left -->
-  <line x1="38" y1="14" x2="20" y2="50" stroke="#FAFAFA" stroke-width="4" stroke-linecap="square"/>
-  <!-- Bottom-right horizontal bar -->
-  <line x1="20" y1="50" x2="54" y2="50" stroke="#FAFAFA" stroke-width="4" stroke-linecap="square"/>
-  <!-- Accent dot at diagonal midpoint -->
-  <circle cx="29" cy="32" r="3.5" fill="#00FF41"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="none">
+  <!-- Background circle -->
+  <rect x="0" y="0" width="512" height="512" rx="96" fill="#0A0A0A"/>
+
+  <!-- Logo Mark centered (scale: 5.3, translate to center) -->
+  <g transform="translate(86, 76) scale(5.3)">
+    <!-- Layer 1: Outer brush stroke curve (stroke) -->
+    <path d="M12 32 C 12 12 20 12 26 16 C 32 20 36 4 48 4 C 62 4 58 28 44 28 C 30 28 34 44 26 44 C 20 44 12 36 12 32 Z" fill="none" stroke="#FAFAFA" stroke-width="0.66" stroke-linecap="round"/>
+
+    <!-- Layer 2: Inner brush stroke curve (fill) -->
+    <path d="M16 32 C 16 16 22 16 28 19 C 34 22 38 10 46 10 C 58 10 54 30 42 30 C 30 30 34 42 28 42 C 22 42 16 34 16 32 Z" fill="#FAFAFA"/>
+
+    <!-- Layer 3: Accent dot (neon green) -->
+    <circle cx="42" cy="20" r="0.66" fill="#00FF41"/>
+  </g>
 </svg>

--- a/public/images/projects/slide-speech.svg
+++ b/public/images/projects/slide-speech.svg
@@ -1,28 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 120" width="400" height="120">
-  <defs>
-    <style>
-      .wordmark { font-family: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif; }
-    </style>
-  </defs>
-  <!-- Background -->
-  <rect width="400" height="120" fill="#FFFFFF" rx="4"/>
-  <!-- Slide icon -->
-  <rect x="20" y="20" width="72" height="54" rx="4" fill="none" stroke="#000000" stroke-width="3"/>
-  <!-- Slide content lines -->
-  <line x1="32" y1="36" x2="64" y2="36" stroke="#6B7280" stroke-width="2" stroke-linecap="round"/>
-  <line x1="32" y1="46" x2="56" y2="46" stroke="#6B7280" stroke-width="1.5" stroke-linecap="round"/>
-  <line x1="32" y1="54" x2="60" y2="54" stroke="#6B7280" stroke-width="1.5" stroke-linecap="round"/>
-  <!-- Slide stand -->
-  <line x1="56" y1="74" x2="56" y2="86" stroke="#000000" stroke-width="2.5" stroke-linecap="round"/>
-  <line x1="42" y1="86" x2="70" y2="86" stroke="#000000" stroke-width="2.5" stroke-linecap="round"/>
-  <!-- Sound wave arcs -->
-  <path d="M 78 38 Q 86 47 78 56" fill="none" stroke="#22C55E" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M 84 32 Q 96 47 84 62" fill="none" stroke="#22C55E" stroke-width="2.5" stroke-linecap="round"/>
-  <path d="M 90 26 Q 106 47 90 68" fill="none" stroke="#22C55E" stroke-width="2" stroke-linecap="round" opacity="0.6"/>
-  <!-- Wordmark -->
-  <text x="118" y="58" class="wordmark" font-size="32" font-weight="700" fill="#000000" letter-spacing="-0.5">slide</text>
-  <text x="118" y="58" class="wordmark" font-size="32" font-weight="700" fill="#000000" letter-spacing="-0.5">slide</text>
-  <text x="193" y="58" class="wordmark" font-size="32" font-weight="700" fill="#22C55E" letter-spacing="-0.5">-speech</text>
-  <!-- Tagline -->
-  <text x="118" y="78" class="wordmark" font-size="11" font-weight="400" fill="#6B7280" letter-spacing="0.5">Automated Presentation Sync</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <rect width="512" height="512" rx="96" fill="#FFFFFF"/>
+  <g transform="translate(96, 96) scale(2.667)">
+    <rect x="24" y="25" width="56" height="42" rx="4" fill="none" stroke="#000000" stroke-width="3"/>
+    <line x1="34" y1="38" x2="60" y2="38" stroke="#6B7280" stroke-width="2" stroke-linecap="round"/>
+    <line x1="34" y1="47" x2="55" y2="47" stroke="#6B7280" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="34" y1="55" x2="58" y2="55" stroke="#6B7280" stroke-width="1.5" stroke-linecap="round"/>
+    <line x1="52" y1="67" x2="52" y2="79" stroke="#000000" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="40" y1="79" x2="64" y2="79" stroke="#000000" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="M66 40 Q73 46 66 52" fill="none" stroke="#22C55E" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="M72 34 Q83 46 72 58" fill="none" stroke="#22C55E" stroke-width="2.5" stroke-linecap="round"/>
+    <path d="M78 30 Q93 46 78 62" fill="none" stroke="#22C55E" stroke-width="2" stroke-linecap="round" opacity="0.6"/>
+  </g>
 </svg>

--- a/public/images/projects/video-to-gif.svg
+++ b/public/images/projects/video-to-gif.svg
@@ -1,39 +1,20 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 120" width="400" height="120">
-  <defs>
-    <style>
-      .wordmark { font-family: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif; }
-    </style>
-  </defs>
-  <!-- Background -->
-  <rect width="400" height="120" fill="#FFFFFF" rx="4"/>
-  <!-- Video frame (left) -->
-  <rect x="16" y="28" width="48" height="36" rx="3" fill="none" stroke="#000000" stroke-width="2.5"/>
-  <!-- Play triangle inside video frame -->
-  <polygon points="34,38 34,56 46,47" fill="#6B7280"/>
-  <!-- Arrow pointing right -->
-  <line x1="70" y1="52" x2="82" y2="52" stroke="#22C55E" stroke-width="2.5" stroke-linecap="round"/>
-  <polyline points="78,46 84,52 78,58" fill="none" stroke="#22C55E" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <!-- GIF loop symbol (circular arrow) -->
-  <circle cx="102" cy="52" r="18" fill="none" stroke="#000000" stroke-width="2.5"/>
-  <!-- Circular arrow indicator -->
-  <path d="M 102 34 L 108 38 L 102 42" fill="none" stroke="#22C55E" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-  <!-- Film strip perforations on video frame -->
-  <rect x="18" y="30" width="4" height="3" rx="0.5" fill="#6B7280" opacity="0.5"/>
-  <rect x="26" y="30" width="4" height="3" rx="0.5" fill="#6B7280" opacity="0.5"/>
-  <rect x="34" y="30" width="4" height="3" rx="0.5" fill="#6B7280" opacity="0.5"/>
-  <rect x="42" y="30" width="4" height="3" rx="0.5" fill="#6B7280" opacity="0.5"/>
-  <rect x="18" y="59" width="4" height="3" rx="0.5" fill="#6B7280" opacity="0.5"/>
-  <rect x="26" y="59" width="4" height="3" rx="0.5" fill="#6B7280" opacity="0.5"/>
-  <rect x="34" y="59" width="4" height="3" rx="0.5" fill="#6B7280" opacity="0.5"/>
-  <rect x="42" y="59" width="4" height="3" rx="0.5" fill="#6B7280" opacity="0.5"/>
-  <!-- GIF text inside loop -->
-  <text x="102" y="56" text-anchor="middle" class="wordmark" font-size="10" font-weight="700" fill="#22C55E">GIF</text>
-  <!-- Wordmark -->
-  <text x="132" y="56" class="wordmark" font-size="30" font-weight="700" fill="#000000" letter-spacing="-0.5">video</text>
-  <text x="214" y="56" class="wordmark" font-size="30" font-weight="700" fill="#6B7280" letter-spacing="-0.5">-to-</text>
-  <text x="274" y="56" class="wordmark" font-size="30" font-weight="700" fill="#22C55E" letter-spacing="-0.5">gif</text>
-  <!-- Tagline -->
-  <text x="132" y="76" class="wordmark" font-size="11" font-weight="400" fill="#6B7280" letter-spacing="0.5">Video to Timelapse GIF</text>
-  <!-- Bottom filmstrip accent -->
-  <rect x="16" y="92" width="108" height="2" rx="1" fill="#22C55E" opacity="0.3"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <rect width="512" height="512" rx="96" fill="#FFFFFF"/>
+  <g transform="translate(56, 136) scale(3.2)">
+    <rect x="16" y="28" width="48" height="36" rx="3" fill="none" stroke="#000000" stroke-width="2.5"/>
+    <polygon points="34,38 34,56 46,47" fill="#6B7280"/>
+    <rect x="18" y="30" width="4" height="3" rx="0.5" fill="#6B7280" opacity="0.5"/>
+    <rect x="26" y="30" width="4" height="3" rx="0.5" fill="#6B7280" opacity="0.5"/>
+    <rect x="34" y="30" width="4" height="3" rx="0.5" fill="#6B7280" opacity="0.5"/>
+    <rect x="42" y="30" width="4" height="3" rx="0.5" fill="#6B7280" opacity="0.5"/>
+    <rect x="18" y="59" width="4" height="3" rx="0.5" fill="#6B7280" opacity="0.5"/>
+    <rect x="26" y="59" width="4" height="3" rx="0.5" fill="#6B7280" opacity="0.5"/>
+    <rect x="34" y="59" width="4" height="3" rx="0.5" fill="#6B7280" opacity="0.5"/>
+    <rect x="42" y="59" width="4" height="3" rx="0.5" fill="#6B7280" opacity="0.5"/>
+    <line x1="70" y1="52" x2="82" y2="52" stroke="#22C55E" stroke-width="2.5" stroke-linecap="round"/>
+    <polyline points="78,46 84,52 78,58" fill="none" stroke="#22C55E" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="102" cy="52" r="18" fill="none" stroke="#000000" stroke-width="2.5"/>
+    <path d="M 102 34 L 108 38 L 102 42" fill="none" stroke="#22C55E" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="102" y="56" text-anchor="middle" font-family="'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="10" font-weight="700" fill="#22C55E">GIF</text>
+  </g>
 </svg>

--- a/public/images/projects/video-to-gif.svg
+++ b/public/images/projects/video-to-gif.svg
@@ -1,26 +1,39 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="none">
-  <rect width="512" height="512" rx="112" fill="#0A0A0A"/>
-
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 120" width="400" height="120">
+  <defs>
+    <style>
+      .wordmark { font-family: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif; }
+    </style>
+  </defs>
+  <!-- Background -->
+  <rect width="400" height="120" fill="#FFFFFF" rx="4"/>
   <!-- Video frame (left) -->
-  <rect x="60" y="160" width="160" height="120" rx="12" fill="#111111" stroke="#374151" stroke-width="3"/>
-  <!-- Play button -->
-  <polygon points="120,200 120,250 158,225" fill="#22C55E"/>
-
-  <!-- Arrow -->
-  <line x1="240" y1="220" x2="290" y2="220" stroke="#22C55E" stroke-width="8" stroke-linecap="round"/>
-  <polygon points="290,205 320,220 290,235" fill="#22C55E"/>
-
-  <!-- GIF frame (right) with sparkle -->
-  <rect x="340" y="160" width="120" height="120" rx="12" fill="#111111" stroke="#22C55E" stroke-width="3"/>
-  <text x="400" y="228" text-anchor="middle" fill="#22C55E" font-family="monospace" font-size="28" font-weight="bold">GIF</text>
-
-  <!-- Film strip decoration -->
-  <rect x="100" y="340" width="312" height="48" rx="8" fill="#111111" stroke="#374151" stroke-width="2"/>
-  <rect x="116" y="350" width="28" height="28" rx="4" fill="#22C55E" opacity="0.3"/>
-  <rect x="156" y="350" width="28" height="28" rx="4" fill="#22C55E" opacity="0.4"/>
-  <rect x="196" y="350" width="28" height="28" rx="4" fill="#22C55E" opacity="0.5"/>
-  <rect x="236" y="350" width="28" height="28" rx="4" fill="#22C55E" opacity="0.6"/>
-  <rect x="276" y="350" width="28" height="28" rx="4" fill="#22C55E" opacity="0.7"/>
-  <rect x="316" y="350" width="28" height="28" rx="4" fill="#22C55E" opacity="0.8"/>
-  <rect x="356" y="350" width="28" height="28" rx="4" fill="#22C55E" opacity="0.9"/>
+  <rect x="16" y="28" width="48" height="36" rx="3" fill="none" stroke="#000000" stroke-width="2.5"/>
+  <!-- Play triangle inside video frame -->
+  <polygon points="34,38 34,56 46,47" fill="#6B7280"/>
+  <!-- Arrow pointing right -->
+  <line x1="70" y1="52" x2="82" y2="52" stroke="#22C55E" stroke-width="2.5" stroke-linecap="round"/>
+  <polyline points="78,46 84,52 78,58" fill="none" stroke="#22C55E" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- GIF loop symbol (circular arrow) -->
+  <circle cx="102" cy="52" r="18" fill="none" stroke="#000000" stroke-width="2.5"/>
+  <!-- Circular arrow indicator -->
+  <path d="M 102 34 L 108 38 L 102 42" fill="none" stroke="#22C55E" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Film strip perforations on video frame -->
+  <rect x="18" y="30" width="4" height="3" rx="0.5" fill="#6B7280" opacity="0.5"/>
+  <rect x="26" y="30" width="4" height="3" rx="0.5" fill="#6B7280" opacity="0.5"/>
+  <rect x="34" y="30" width="4" height="3" rx="0.5" fill="#6B7280" opacity="0.5"/>
+  <rect x="42" y="30" width="4" height="3" rx="0.5" fill="#6B7280" opacity="0.5"/>
+  <rect x="18" y="59" width="4" height="3" rx="0.5" fill="#6B7280" opacity="0.5"/>
+  <rect x="26" y="59" width="4" height="3" rx="0.5" fill="#6B7280" opacity="0.5"/>
+  <rect x="34" y="59" width="4" height="3" rx="0.5" fill="#6B7280" opacity="0.5"/>
+  <rect x="42" y="59" width="4" height="3" rx="0.5" fill="#6B7280" opacity="0.5"/>
+  <!-- GIF text inside loop -->
+  <text x="102" y="56" text-anchor="middle" class="wordmark" font-size="10" font-weight="700" fill="#22C55E">GIF</text>
+  <!-- Wordmark -->
+  <text x="132" y="56" class="wordmark" font-size="30" font-weight="700" fill="#000000" letter-spacing="-0.5">video</text>
+  <text x="214" y="56" class="wordmark" font-size="30" font-weight="700" fill="#6B7280" letter-spacing="-0.5">-to-</text>
+  <text x="274" y="56" class="wordmark" font-size="30" font-weight="700" fill="#22C55E" letter-spacing="-0.5">gif</text>
+  <!-- Tagline -->
+  <text x="132" y="76" class="wordmark" font-size="11" font-weight="400" fill="#6B7280" letter-spacing="0.5">Video to Timelapse GIF</text>
+  <!-- Bottom filmstrip accent -->
+  <rect x="16" y="92" width="108" height="2" rx="1" fill="#22C55E" opacity="0.3"/>
 </svg>

--- a/public/images/projects/vscode-theme-neon-green.svg
+++ b/public/images/projects/vscode-theme-neon-green.svg
@@ -1,34 +1,43 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="none">
-  <rect width="512" height="512" rx="112" fill="#0A0A0A"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="neonGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4dff4d"/>
+      <stop offset="50%" stop-color="#39ff14"/>
+      <stop offset="100%" stop-color="#00e676"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="10" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="0 0 0 0 0.224  0 0 0 0 1  0 0 0 0 0.078  0 0 0 0.6 0" result="greenBlur"/>
+      <feMerge>
+        <feMergeNode in="greenBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <filter id="softGlow">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="20" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="0 0 0 0 0.224  0 0 0 0 1  0 0 0 0 0.078  0 0 0 0.25 0"/>
+    </filter>
+  </defs>
 
-  <!-- VS Code window frame -->
-  <rect x="80" y="100" width="352" height="312" rx="16" fill="#111111" stroke="#1A1A1A" stroke-width="3"/>
+  <!-- Background with padding -->
+  <rect width="512" height="512" rx="96" fill="#0a0f0a"/>
 
-  <!-- Title bar -->
-  <rect x="80" y="100" width="352" height="36" rx="16" fill="#1A1A1A"/>
-  <rect x="80" y="120" width="352" height="16" fill="#1A1A1A"/>
-  <circle cx="108" cy="118" r="6" fill="#EF4444"/>
-  <circle cx="132" cy="118" r="6" fill="#F59E0B"/>
-  <circle cx="156" cy="118" r="6" fill="#22C55E"/>
+  <!-- Ambient glow -->
+  <g filter="url(#softGlow)">
+    <path d="M144 384 L144 128 L368 384 L368 128" fill="none" stroke="#39ff14" stroke-width="48" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
 
-  <!-- Sidebar -->
-  <rect x="80" y="136" width="60" height="276" fill="#0D0D0D"/>
+  <!-- Main N mark -->
+  <g filter="url(#glow)">
+    <path d="M144 384 L144 128 L368 384 L368 128" fill="none" stroke="url(#neonGrad)" stroke-width="36" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
 
-  <!-- Code lines with neon green -->
-  <rect x="160" y="160" width="120" height="8" rx="4" fill="#22C55E" opacity="0.9"/>
-  <rect x="176" y="184" width="180" height="8" rx="4" fill="#22C55E" opacity="0.6"/>
-  <rect x="176" y="208" width="140" height="8" rx="4" fill="#22C55E" opacity="0.4"/>
-  <rect x="176" y="232" width="200" height="8" rx="4" fill="#22C55E" opacity="0.7"/>
-  <rect x="160" y="256" width="80" height="8" rx="4" fill="#22C55E" opacity="0.5"/>
-  <rect x="176" y="280" width="160" height="8" rx="4" fill="#22C55E" opacity="0.3"/>
-  <rect x="160" y="304" width="100" height="8" rx="4" fill="#22C55E" opacity="0.8"/>
-  <rect x="176" y="328" width="220" height="8" rx="4" fill="#22C55E" opacity="0.5"/>
-  <rect x="160" y="352" width="60" height="8" rx="4" fill="#22C55E" opacity="0.6"/>
+  <!-- Inner bright core -->
+  <path d="M144 384 L144 128 L368 384 L368 128" fill="none" stroke="#ffffff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" opacity="0.5"/>
 
-  <!-- Neon glow effect -->
-  <rect x="80" y="100" width="352" height="312" rx="16" fill="none" stroke="#22C55E" stroke-width="2" opacity="0.3"/>
-
-  <!-- Paint drop -->
-  <circle cx="256" cy="440" r="20" fill="#22C55E"/>
-  <path d="M256 420 L268 440 L244 440 Z" fill="#22C55E"/>
+  <!-- Corner accents -->
+  <circle cx="144" cy="128" r="7" fill="#4dff4d" opacity="0.8"/>
+  <circle cx="368" cy="128" r="7" fill="#4dff4d" opacity="0.8"/>
+  <circle cx="144" cy="384" r="7" fill="#4dff4d" opacity="0.8"/>
+  <circle cx="368" cy="384" r="7" fill="#4dff4d" opacity="0.8"/>
 </svg>

--- a/scripts/sync-project-logos.mjs
+++ b/scripts/sync-project-logos.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+import { copyFileSync, existsSync, readFileSync, writeFileSync } from 'fs'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(__dirname, '..')
+const BUILDSPACE = join(ROOT, '..')
+const DEST = join(ROOT, 'public/images/projects')
+const PORTFOLIO = join(ROOT, 'src/data/portfolio.json')
+const PROJECTS = join(ROOT, 'src/data/projects.json')
+
+/** portfolio name -> local repo folder under buildspace */
+const REPO_DIRS = {
+  'claude-howto': 'claude-howto',
+  'agent-skill-manager': 'asm',
+  skills: 'skills',
+  'cc-context-stats': 'context-stats',
+  'music-cli': 'music-cli',
+  ccl: 'ccl',
+  'sleek-ui': 'sleek-ui',
+  idd: 'idd',
+  'voice-cast': 'voicecast',
+  'vscode-markdown-preview': 'vscode-markdown-preview',
+  'repo-insights': 'repo-insights',
+  'doc-bases': 'doc-bases',
+  'bluetooth-diagnostic': 'bluetooth-diagnostic',
+  'vscode-theme-neon-green': 'vscode-theme-neon-green',
+  'video-to-gif': 'video-to-gif',
+  mdoctor: 'mdoctor',
+  'git-auto-switch': 'git-auto-switch',
+  'slide-speech': 'slide-speech',
+  inbash: 'inbash',
+  'llm-cli': 'llm-cli',
+}
+
+const CANDIDATES = [
+  'assets/logo/logo-icon.svg',
+  'assets/logo/logo-mark.svg',
+  'assets/logo/logo-full.svg',
+  'logo-icon.svg',
+  'logo.svg',
+  'resources/logos/claude-howto-logo.svg',
+  'icon.svg',
+]
+
+function findLogo(repoDir) {
+  for (const rel of CANDIDATES) {
+    const p = join(repoDir, rel)
+    if (existsSync(p)) return p
+  }
+  return null
+}
+
+const portfolio = JSON.parse(readFileSync(PORTFOLIO, 'utf8'))
+const results = []
+
+for (const project of portfolio.projects) {
+  const folder = REPO_DIRS[project.name]
+  const logoPath = `/images/projects/${project.name}.svg`
+
+  if (!folder) {
+    results.push({ name: project.name, status: 'no repo mapping' })
+    continue
+  }
+
+  const repoDir = join(BUILDSPACE, folder)
+  const src = findLogo(repoDir)
+
+  if (!src) {
+    results.push({ name: project.name, status: 'no logo in repo', repoDir })
+    project.logo = logoPath
+    continue
+  }
+
+  const destFile = join(DEST, `${project.name}.svg`)
+  copyFileSync(src, destFile)
+  project.logo = logoPath
+  results.push({ name: project.name, status: 'copied', from: src })
+}
+
+writeFileSync(PORTFOLIO, `${JSON.stringify(portfolio, null, 2)}\n`)
+
+if (existsSync(PROJECTS)) {
+  const projectsFile = JSON.parse(readFileSync(PROJECTS, 'utf8'))
+  for (const project of projectsFile.projects) {
+    const folder = REPO_DIRS[project.name]
+    if (!folder) continue
+    const repoDir = join(BUILDSPACE, folder)
+    const src = findLogo(repoDir)
+    if (src) {
+      const destFile = join(DEST, `${project.name}.svg`)
+      if (!existsSync(destFile)) copyFileSync(src, destFile)
+      project.icon = `/images/projects/${project.name}.svg`
+    }
+  }
+  writeFileSync(PROJECTS, `${JSON.stringify(projectsFile, null, 2)}\n`)
+  console.log('✓ updated src/data/projects.json icons')
+}
+
+for (const r of results) {
+  if (r.status === 'copied') console.log(`✓ ${r.name}`)
+  else console.log(`⚠ ${r.name}: ${r.status}${r.repoDir ? ` (${r.repoDir})` : ''}`)
+}

--- a/scripts/sync-project-logos.mjs
+++ b/scripts/sync-project-logos.mjs
@@ -52,6 +52,29 @@ function findLogo(repoDir) {
   return null
 }
 
+/** @returns {{ w: number, h: number } | null} */
+function svgViewBoxSize(filePath) {
+  try {
+    const svg = readFileSync(filePath, 'utf8')
+    const m = svg.match(/viewBox=["']\s*0\s+0\s+([\d.]+)\s+([\d.]+)\s*["']/)
+    if (m) return { w: Number(m[1]), h: Number(m[2]) }
+  } catch {
+    /* ignore */
+  }
+  return null
+}
+
+function warnIfWideWordmark(name, filePath, srcRel) {
+  const size = svgViewBoxSize(filePath)
+  if (!size || size.h <= 0) return
+  const ratio = size.w / size.h
+  if (ratio > 1.35) {
+    console.warn(
+      `⚠ ${name}: wide logo (${size.w}×${size.h}) from ${srcRel} — portfolio cards need a square icon; add assets/logo/logo-icon.svg or a dedicated square SVG`,
+    )
+  }
+}
+
 const portfolio = JSON.parse(readFileSync(PORTFOLIO, 'utf8'))
 const results = []
 
@@ -75,6 +98,8 @@ for (const project of portfolio.projects) {
 
   const destFile = join(DEST, `${project.name}.svg`)
   copyFileSync(src, destFile)
+  const srcRel = src.startsWith(repoDir) ? join(folder, src.slice(repoDir.length + 1)) : src
+  warnIfWideWordmark(project.name, destFile, srcRel)
   project.logo = logoPath
   results.push({ name: project.name, status: 'copied', from: src })
 }

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -2,6 +2,7 @@ import { PortfolioCard } from './PortfolioCard'
 import portfolioData from '@/data/portfolio.json'
 import privatePortfolioData from '@/data/private-portfolio.json'
 
+/** First N entries in portfolio.json are the featured OSS grid; the rest go in "More OSS projects". */
 const FEATURED_OSS_LIMIT = 8
 
 const productProjects = [
@@ -25,16 +26,14 @@ const productProjects = [
 const privateProjectNames = ['travels', 'ideas', 'notes', 'blogs']
 
 export function Portfolio() {
-  const sortedOssProjects = [...portfolioData.projects].sort(
-    (a, b) => (b.stars ?? 0) - (a.stars ?? 0),
-  )
+  const featuredOssProjects = portfolioData.projects
+    .slice(0, FEATURED_OSS_LIMIT)
+    .map((project) => ({
+      ...project,
+      displayName: project.name === 'agent-skill-manager' ? 'asm' : project.name,
+    }))
 
-  const featuredOssProjects = sortedOssProjects.slice(0, FEATURED_OSS_LIMIT).map((project) => ({
-    ...project,
-    displayName: project.name === 'agent-skill-manager' ? 'asm' : project.name,
-  }))
-
-  const remainingOssProjects = sortedOssProjects.slice(FEATURED_OSS_LIMIT)
+  const remainingOssProjects = portfolioData.projects.slice(FEATURED_OSS_LIMIT)
 
   const personalFlowProjects = privatePortfolioData.projects.filter(({ name }) =>
     privateProjectNames.includes(name),

--- a/src/data/portfolio.json
+++ b/src/data/portfolio.json
@@ -7,6 +7,7 @@
       "stars": 37003,
       "forks": 4462,
       "url": "https://github.com/luongnv89/claude-howto",
+      "landingPage": "https://luongnv.com/claude-howto",
       "logo": "/images/projects/claude-howto.svg"
     },
     {
@@ -34,6 +35,7 @@
       "language": "Python",
       "stars": 107,
       "url": "https://github.com/luongnv89/cc-context-stats",
+      "landingPage": "https://luongnv.com/context-stats",
       "logo": "/images/projects/cc-context-stats.svg",
       "forks": 11
     },
@@ -46,6 +48,36 @@
       "landingPage": "https://music-cli.luongnv.com",
       "logo": "/images/projects/music-cli.svg",
       "forks": 27
+    },
+    {
+      "name": "ccl",
+      "description": "Hit your limit? Need privacy? Just swap the model, everything else stays",
+      "language": "Python",
+      "stars": 33,
+      "url": "https://github.com/luongnv89/ccl",
+      "landingPage": "https://luongnv.com/ccl",
+      "logo": "/images/projects/ccl.svg",
+      "forks": 1
+    },
+    {
+      "name": "sleek-ui",
+      "description": "Modern, minimal UI component library — accessible, themeable, and designed for developers who want beautiful defaults without the bloat",
+      "language": "TypeScript",
+      "stars": 125,
+      "url": "https://github.com/luongnv89/sleek-ui",
+      "landingPage": "https://luongnv.com/sleek-ui",
+      "logo": "/images/projects/sleek-ui.svg",
+      "forks": 11
+    },
+    {
+      "name": "idd",
+      "description": "Turn GitHub Issues into structured, agent-ready work orders",
+      "language": "Shell",
+      "stars": 1,
+      "url": "https://github.com/luongnv89/idd",
+      "landingPage": "https://luongnv.com/idd",
+      "logo": "/images/projects/idd.svg",
+      "forks": 0
     },
     {
       "name": "voice-cast",
@@ -76,22 +108,12 @@
       "forks": 0
     },
     {
-      "name": "sleek-ui",
-      "description": "Modern, minimal UI component library — accessible, themeable, and designed for developers who want beautiful defaults without the bloat",
-      "language": "TypeScript",
-      "stars": 125,
-      "url": "https://github.com/luongnv89/sleek-ui",
-      "landingPage": "https://luongnv.com/sleek-ui",
-      "logo": "/images/projects/sleek-ui.svg",
-      "forks": 11
-    },
-    {
       "name": "doc-bases",
       "description": "Intelligent answers from any document",
       "language": "Python",
       "stars": 4,
       "url": "https://github.com/luongnv89/doc-bases",
-      "logo": "/images/projects/doc-bases-icon.svg",
+      "logo": "/images/projects/doc-bases.svg",
       "forks": 1
     },
     {
@@ -109,6 +131,7 @@
       "language": "JavaScript",
       "stars": 0,
       "url": "https://github.com/luongnv89/vscode-theme-neon-green",
+      "landingPage": "https://luongnv.com/vscode-theme-neon-green",
       "logo": "/images/projects/vscode-theme-neon-green.svg",
       "forks": 0
     },
@@ -145,7 +168,7 @@
       "language": "Python",
       "stars": 3,
       "url": "https://github.com/luongnv89/slide-speech",
-      "logo": "/images/projects/slide-speech-icon.svg",
+      "logo": "/images/projects/slide-speech.svg",
       "forks": 0
     },
     {

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -6,7 +6,8 @@
       "language": "Python",
       "stars": 33,
       "url": "https://github.com/luongnv89/ccl",
-      "forks": 1
+      "forks": 1,
+      "icon": "/images/projects/ccl.svg"
     },
     {
       "name": "claude-howto",
@@ -23,7 +24,8 @@
       "language": "Python",
       "stars": 107,
       "url": "https://github.com/luongnv89/cc-context-stats",
-      "forks": 11
+      "forks": 11,
+      "icon": "/images/projects/cc-context-stats.svg"
     },
     {
       "name": "music-cli",
@@ -98,7 +100,8 @@
       "description": "Automate presentations — play synced audio for each slide, timed to each audio file's duration",
       "language": "Python",
       "stars": 3,
-      "url": "https://github.com/luongnv89/slide-speech"
+      "url": "https://github.com/luongnv89/slide-speech",
+      "icon": "/images/projects/slide-speech.svg"
     },
     {
       "name": "doc-bases",
@@ -106,7 +109,8 @@
       "language": "Python",
       "stars": 4,
       "url": "https://github.com/luongnv89/doc-bases",
-      "forks": 1
+      "forks": 1,
+      "icon": "/images/projects/doc-bases.svg"
     },
     {
       "name": "sleek-ui",
@@ -114,7 +118,8 @@
       "language": "TypeScript",
       "stars": 125,
       "url": "https://github.com/luongnv89/sleek-ui",
-      "forks": 11
+      "forks": 11,
+      "icon": "/images/projects/sleek-ui.svg"
     },
     {
       "name": "video-to-gif",
@@ -154,7 +159,8 @@
       "language": "Shell",
       "stars": 1,
       "url": "https://github.com/luongnv89/llm-cli",
-      "forks": 1
+      "forks": 1,
+      "icon": "/images/projects/llm-cli.svg"
     },
     {
       "name": "inbash",
@@ -162,7 +168,8 @@
       "language": "Shell",
       "stars": 1,
       "url": "https://github.com/luongnv89/inbash",
-      "forks": 1
+      "forks": 1,
+      "icon": "/images/projects/inbash.svg"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- **Featured OSS grid** is driven by order in `portfolio.json` (no longer sorted by stars).
- **Featured:** added **ccl** and **idd**; **voice-cast** and **vscode-markdown-preview** moved to the collapsed “More OSS projects” section.
- **Landing pages:** added or verified Website links where `luongnv.com` (or `music-cli.luongnv.com`) returns a real project page.
- **Logos:** copied canonical marks from local repos under `~/buildspace/luongnv89/` into `public/images/projects/`; added `scripts/sync-project-logos.mjs` to refresh portfolio + featured-projects icons.

## Test plan
- [ ] `npm run build` passes
- [ ] OSS section shows 8 featured cards including ccl and idd
- [ ] Expand “More OSS projects” — voice-cast and vscode-markdown-preview appear there
- [ ] Flip cards — Website link works for projects with `landingPage`

Type: chore
